### PR TITLE
Update README.md: fix link to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ technologies used on websites. It detects
 
 ## Documentation
 
-Please read the [developer documentation](https://www.wappalyzer.com/docs) to get started.
+Please read the [developer documentation](https://docs.wappalyzer.com/) to get started.


### PR DESCRIPTION
Current link https://www.wappalyzer.com/docs displays a 404 not found error as it appears the documentation now lives at https://docs.wappalyzer.com/